### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.8 as build-stage
+WORKDIR /go/src/sonar
+COPY cmd/sonar/main.go .
+RUN go get && CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o sonar .
+
+FROM alpine:latest
+WORKDIR /app
+COPY --from=build-stage /go/src/sonar /app
+COPY wordlist.txt /app
+ENTRYPOINT ["/app/sonar"]


### PR DESCRIPTION
Adds a Dockerfile for sonar. This uses a [multi-stage build](https://docs.docker.com/engine/userguide/eng-image/multistage-build/), which requires Docker 17.05+

I added this build to my DockerHub account, and it can be run as follows:

```
docker run --rm wittman/sonar example.com
```